### PR TITLE
Corrected mongoose connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,13 @@ var fs = require('fs');
 var mongoose = require('mongoose');
 
 //mongoose connect
-var connection = mongoose.connect('mongodb://localhost/test');
+mongoose.connect('mongodb://localhost/test');
 
 //instantiate mongoose-gridfs
 var gridfs = require('mongoose-gridfs')({
   collection:'attachments',
   model:'Attachment',
-  mongooseConnection: connection
+  mongooseConnection: mongoose.connection
 });
 
 //obtain a model


### PR DESCRIPTION
fix #10 Mongoose changed their connection object returned on original connection or gridfs wants something different, giving it the connection from the mongoose object seems to fix it up.