### PR TITLE
Add TypeScript compatibility

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,7 @@
       // Types should go into this directory.
       // Removing this would place the .d.ts files
       // next to the .js files
-      // "outDir": "DESTINATION_DIR_HERE"
+      // "outDir": "DESTINATION_DIR_HERE" -->Specify the directory name, to be the same as build folder of the main file, if using any build tools.
       // go to js file when using IDE functions like
       // "Go to Definition" in VSCode
       "declarationMap": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,31 @@
+{
+    
+    "compilerOptions": {
+      // Tells TypeScript to read JS files, as
+      // normally they are ignored as source files
+      "allowJs": true,
+      // Generate d.ts files
+      "declaration": true,
+      // This compiler run should
+      // only output d.ts files
+      "emitDeclarationOnly": true,
+
+      "strict": true,
+      // Types should go into this directory.
+      // Removing this would place the .d.ts files
+      // next to the .js files
+      // "outDir": "DESTINATION_DIR_HERE"
+      // go to js file when using IDE functions like
+      // "Go to Definition" in VSCode
+      "declarationMap": true,
+      "composite": true
+    },
+    "include": ["lib"] //lib directory containins the main index.js file is packeed for npm package, hence add type definition to index.js only. 
+}
+
+
+
+
+
+
+  

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,10 +22,3 @@
     },
     "include": ["lib"] //lib directory containins the main index.js file is packeed for npm package, hence add type definition to index.js only. 
 }
-
-
-
-
-
-
-  


### PR DESCRIPTION
There are two ways to add a type definition file to enable TypeScript compatibility.

This file should be placed directly under the root directory and not in any of the sub-directories. 

1. If you are using any bundling or build tools, such as webpack, you are likely exporting/building a single file defined in the `output`'s `path` attribute. In such a case, you could navigate to the build folder after running `npm pack` and run the command `npx tsc` to add a type definition file for `index.js` (If `d.ts` is generated for any other file other than `index.js`, you may delete it manually). If you are going ahead with this approach, kindly uncomment the `outDir` attribute in this file and specify the output folder(To be the same as the build folder of the main file).
2. Navigate to `lib` folder and run `npx tsc` before packing it to an npm package, I tried this locally in my project without running `npm pack`, as It is obvious that I'm not rebuilding this package. This is working fine for me.

Following any of the two above methods, adds the type definition by default, meaning there's no need for the end-user to install the types separately by running `npm install --save-dev @types/mongoose-gridfs`.

Tested and works on the following version:
```
"devDependencies": {
    "@types/express": "^4.17.13",
    "@types/multer": "^1.4.7",
    "@types/node": "^17.0.5",
    "ts-node-dev": "^1.1.8",
    "typescript": "^4.5.4"
  },
  "dependencies": {
    "express": "^4.17.2",
    "mongodb": "^4.3.0",
    "mongoose": "^6.1.6",
    "mongoose-gridfs": "^1.3.0",
    "multer": "^1.4.4"
  }
```